### PR TITLE
Make channel names clickable in Web UI

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -242,6 +242,8 @@
         .priority-legend-badge.p1 { background: rgba(255, 192, 0, 0.2); color: var(--yellow); }
         .priority-legend-badge.p2 { background: var(--border); color: var(--text-muted); }
 
+        td a[target="_blank"]:hover strong { color: var(--purple); }
+
         .game-name {
             color: var(--text-secondary);
             font-size: 13px;
@@ -704,7 +706,7 @@
                                 ${priLabel}
                             </button>
                         </td>
-                        <td><strong>${escapeHtml(ch.display_name)}</strong>${tempBadge}${dropHtml}</td>
+                        <td><a href="https://twitch.tv/${encodeURIComponent(ch.login)}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><strong>${escapeHtml(ch.display_name)}</strong></a>${tempBadge}${dropHtml}</td>
                         <td>${statusBadge}</td>
                         <td class="game-name" title="${escapeHtml(ch.game_name || '')}">${escapeHtml(ch.game_name || '-')}</td>
                         <td class="viewers">${ch.is_online ? ch.viewer_count.toLocaleString() : '-'}</td>


### PR DESCRIPTION
## Summary
- Channel names in the Web UI channels table now link to their Twitch stream (`twitch.tv/{login}`)
- Opens in a new tab (`target="_blank"`)
- Purple hover effect for visual feedback

## Test plan
- [ ] Open Web UI, verify channel names are clickable
- [ ] Click a channel name — should open Twitch stream in new tab
- [ ] Hover over name — should turn purple