### PR TITLE
fix(drops): credit drop minutes via Spade heartbeats with game attribution (Twitch change 2026-07-10)

### DIFF
--- a/internal/drops/apply.go
+++ b/internal/drops/apply.go
@@ -38,6 +38,10 @@ func (s *Service) ApplyPick(pick *PoolEntry, campaigns []twitch.DropCampaign) Ap
 				// Clear IsWatching so rotation can pick this channel up
 				// again as a normal Spade slot.
 				ch.SetWatching(false)
+				// The pick owned a Spade heartbeat slot (see step 8);
+				// release it. Rotation restarts one if the channel gets
+				// a points slot again.
+				s.spade.StopWatching(prevPickID)
 			}
 			s.UnsubscribeBroadcastSettings(prevPickID)
 		}
@@ -149,6 +153,8 @@ func (s *Service) ApplyPick(pick *PoolEntry, campaigns []twitch.DropCampaign) Ap
 		if prevCh, ok := s.channels.Get(prevPickID); ok {
 			prevCh.ClearDropInfo()
 			prevCh.SetWatching(false)
+			// Release the pick-owned Spade heartbeat slot (see step 8).
+			s.spade.StopWatching(prevPickID)
 		}
 		s.UnsubscribeBroadcastSettings(prevPickID)
 	}
@@ -157,12 +163,30 @@ func (s *Service) ApplyPick(pick *PoolEntry, campaigns []twitch.DropCampaign) Ap
 	s.SubscribeBroadcastSettings(pick.ChannelID)
 
 	// 8. Hand the channel to the drops Watcher.
+	//
+	// 2026-07-10: Twitch stopped crediting drop minutes via the GQL
+	// sendSpadeEvents mutation (the Watcher's send_watch path) — sessions
+	// stay nil or the minute counter freezes, on every campaign.
+	// DevilXD/TwitchDropsMiner#1099 is the same breakage. Drop credit now
+	// flows through the Spade POST pipeline instead, provided the payload
+	// carries game/game_id and an INT user_id (see sendHeartbeat). The
+	// pick therefore now gets Spade heartbeats IN ADDITION to the Watcher
+	// (which still does the DropCurrentSessionContext progress polling) —
+	// pre-change this line was s.spade.StopWatching(snap.ChannelID).
 	if s.watcher != nil {
-		s.spade.StopWatching(snap.ChannelID)
 		s.prober.Stop(snap.Login)
 		ch.SetWatching(true) // for UI display
+		// Watcher first: Rotate() keys off watcher.CurrentChannelID to
+		// reserve a heartbeat slot for the pick (see points/rotation.go),
+		// so it must already report the new pick when we kick rotation.
 		s.watcher.Start(snap.ChannelID, snap.Login, snap.BroadcastID, snap.GameName, snap.GameID)
-		s.log("[Drops/Watch] handing %s to drops Watcher (exclusive)", snap.DisplayName)
+		if s.triggerRotation != nil {
+			s.triggerRotation()
+		}
+		if !s.spade.StartWatching(snap.ChannelID, snap.Login, snap.BroadcastID, snap.GameName, snap.GameID) {
+			s.log("[Drops/Watch] WARNING: no free Spade slot for %s — drop minutes will not credit", snap.DisplayName)
+		}
+		s.log("[Drops/Watch] handing %s to drops Watcher (exclusive+spade)", snap.DisplayName)
 	}
 
 	// Reset the silent-pick stall clock so PollProgressOnce gives this
@@ -218,6 +242,9 @@ func (s *Service) RefreshWatcherBroadcast(channelID, login string) {
 		ch.SetOnlineWithGameID(info.BroadcastID, info.GameName, info.GameID, info.ViewerCount, info.StreamCreatedAt)
 	}
 	s.watcher.UpdateBroadcast(channelID, info.BroadcastID, info.GameName, info.GameID)
+	// Keep the pick's Spade heartbeats (step 8) on the fresh broadcast_id
+	// too — stale IDs make Twitch silently drop the events.
+	s.spade.UpdateBroadcastID(channelID, info.BroadcastID)
 }
 
 // HandleGameChange reacts to a broadcast-settings-update PubSub event.

--- a/internal/points/rotation.go
+++ b/internal/points/rotation.go
@@ -154,9 +154,18 @@ func (s *Service) Rotate() {
 	// Build the desired watch set: P0 → PS → P1 → P2 (rotated cursor).
 	desired := make(map[string]*channels.State)
 
+	// Since 2026-07-10 the drop pick needs a Spade heartbeat slot of its
+	// own (drop credit moved onto the Spade POST pipeline — see
+	// drops/apply.go step 8), so rotation must leave one slot free while
+	// a pick is active. The pick itself is excluded from the lists above.
+	slotLimit := maxSpadeSlots
+	if dropChanID != "" {
+		slotLimit--
+	}
+
 	slotsUsed := 0
 	for _, ch := range priority0 {
-		if slotsUsed >= maxSpadeSlots {
+		if slotsUsed >= slotLimit {
 			break
 		}
 		desired[ch.ChannelID] = ch
@@ -168,7 +177,7 @@ func (s *Service) Rotate() {
 	// (30min hard cap), then drops back to P2 next tick.
 	sortStreakCandidates(priorityStreak)
 	for _, ch := range priorityStreak {
-		if slotsUsed >= maxSpadeSlots {
+		if slotsUsed >= slotLimit {
 			break
 		}
 		desired[ch.ChannelID] = ch
@@ -176,14 +185,14 @@ func (s *Service) Rotate() {
 	}
 
 	for _, ch := range priority1 {
-		if slotsUsed >= maxSpadeSlots {
+		if slotsUsed >= slotLimit {
 			break
 		}
 		desired[ch.ChannelID] = ch
 		slotsUsed++
 	}
 
-	remainingSlots := maxSpadeSlots - slotsUsed
+	remainingSlots := slotLimit - slotsUsed
 	if remainingSlots > 0 && len(priority2) > 0 {
 		s.mu.Lock()
 		idx := s.rotationIndex % len(priority2)

--- a/internal/twitch/spade.go
+++ b/internal/twitch/spade.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -30,11 +31,12 @@ const (
 	browserUserAgent = "Dalvik/2.1.0 (Linux; U; Android 16; SM-S911B Build/TP1A.220624.014) tv.twitch.android.app/25.3.0/2503006"
 )
 
-// SpadeTracker sends minute-watched heartbeats for CHANNEL-POINTS WATCH
-// credit. It POSTs the legacy event payload to the beacon/spade endpoint
-// resolved at Start() (see fetchSpadeURL). Drop-minute credit is a
-// separate pipeline — drops.Watcher uses the sendSpadeEvents GQL mutation
-// with INT user_id + game_id and does not go through this tracker.
+// SpadeTracker sends minute-watched heartbeats for watch credit. It
+// POSTs the legacy event payload to the beacon/spade endpoint resolved
+// at Start() (see fetchSpadeURL). Since 2026-07-10 this pipeline carries
+// BOTH channel-points WATCH credit AND drop-minute credit (Twitch killed
+// crediting via the sendSpadeEvents GQL mutation, so the drops pick now
+// holds a heartbeat slot here too — see drops/apply.go step 8).
 // See sendHeartbeat for the long-form pipeline rationale.
 type SpadeTracker struct {
 	userID     string
@@ -207,21 +209,23 @@ func (s *SpadeTracker) heartbeatLoop(ch *spadeChannel) {
 
 const heartbeatMaxRetries = 2
 
-// sendHeartbeat posts the minute-watched event for channel-points credit.
+// sendHeartbeat posts the minute-watched event for watch credit.
 //
-// Twitch has TWO separate credit pipelines and they verify differently:
+// Pipeline history:
 //
-//   - Channel-points WATCH credit goes through the legacy
-//     spade.twitch.tv/track (or beacon.twitch.tv/track) POST endpoint
-//     with `player: "site"` / `location: "channel"`. Drops do NOT credit
-//     through this path — that was the v1.5/v1.6 confusion.
-//   - Drop-minute credit goes through the `sendSpadeEvents` GraphQL
-//     mutation with `game_id` and INT user_id. drops.Watcher uses that
-//     path independently.
-//
-// SpadeTracker only handles channel-points farming, so it sticks with
-// POST. The drops Watcher takes its picked channel exclusively (Spade
-// skips it) so there's no double-credit risk.
+//   - Pre-2026-07-10, Twitch had TWO separate credit pipelines: channel-
+//     points WATCH via this POST endpoint (`player: "site"` /
+//     `location: "channel"`), drop minutes via the `sendSpadeEvents`
+//     GraphQL mutation (drops.Watcher's path).
+//   - 2026-07-10: Twitch stopped crediting drop minutes via the GQL
+//     mutation entirely (DevilXD/TwitchDropsMiner#1099 broke the same
+//     day). Drop credit now ALSO flows through this POST pipeline — but
+//     only when the payload carries the game attribution fields (`game`,
+//     `game_id`) and an INT `user_id`. A real browser has always sent
+//     these fields, and channel-points credit is unaffected by them.
+//     Independently confirmed by INKCR0W/TwitchDropsMinerGo commits
+//     f590d9b + 63b3287 (2026-07-10): their minimal payload got 204
+//     without crediting; adding game/game_id made drops credit.
 //
 // Restored 2026-04-29 after the v2.0 ABI fix accidentally collapsed both
 // pipelines onto sendSpadeEvents — drops kept crediting, but channel-
@@ -239,22 +243,34 @@ func (s *SpadeTracker) sendHeartbeat(ch *spadeChannel) {
 	channelID := ch.channelID
 	channelLogin := ch.channelLogin
 	broadcastID := ch.broadcastID
+	gameName := ch.gameName
+	gameID := ch.gameID
 	s.mu.Unlock()
+
+	// INT user_id, not string — same rule as the GQL variant (gql.go):
+	// Twitch's drop-credit pipeline validates the type; a string user_id
+	// returns 204 but the credit is silently dropped.
+	uidInt, _ := strconv.ParseInt(s.userID, 10, 64)
 
 	payload := []map[string]interface{}{
 		{
 			"event": "minute-watched",
 			"properties": map[string]interface{}{
-				"channel_id":   channelID,
-				"broadcast_id": broadcastID,
-				"player":       "site",
-				"user_id":      s.userID,
-				"channel":      channelLogin,
-				"hidden":       false,
-				"live":         true,
-				"location":     "channel",
-				"logged_in":    true,
-				"muted":        false,
+				"channel_id":     channelID,
+				"broadcast_id":   broadcastID,
+				"player":         "site",
+				"user_id":        uidInt,
+				"channel":        channelLogin,
+				"client_time":    time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+				"game":           gameName,
+				"game_id":        gameID,
+				"hidden":         false,
+				"is_live":        true,
+				"live":           true,
+				"location":       "channel",
+				"logged_in":      true,
+				"minutes_logged": 1,
+				"muted":          false,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

On **July 10, 2026** Twitch stopped crediting drop minutes for all miner tools (see DevilXD/TwitchDropsMiner#1099, opened the same day). Symptom in twitchpoint: the drops Watcher keeps sending heartbeats without errors, but `DropCurrentSessionContext` either returns nil or the minute counter freezes — on every campaign. Channel points keep working normally.

## Root cause

Drop-minute credit no longer flows through the `sendSpadeEvents` GraphQL mutation (the path `drops.Watcher` / `GQLClient.SendMinuteWatched` uses). The mutation still returns `statusCode: 204`, but Twitch silently discards the credit. This is exactly why TwitchDropsMiner broke on the same day — it uses the same mechanism.

Drop credit now goes through the classic **spade/beacon POST pipeline** (what `SpadeTracker.sendHeartbeat` already implements for channel points), **but only if the payload carries the game attribution fields**. The current `SpadeTracker` payload was built for channel points and omits them, so it credits points but not drops.

## Changes

**`internal/twitch/spade.go` — `sendHeartbeat` payload:**
- add `game` and `game_id` (without them Twitch answers 204 but never credits game-attributed drops)
- send `user_id` as **INT, not string** — the same type-strictness already documented in `SendMinuteWatched` for the GQL variant
- add `client_time` / `is_live` / `minutes_logged` like a real web client

**`internal/drops/apply.go` — the pick now holds a Spade heartbeat slot:**
- step 8 starts Spade heartbeats for the pick instead of stopping them (pre-change line was `s.spade.StopWatching(...)`); the slot is released on every pick-release path
- `RefreshWatcherBroadcast` also pushes fresh broadcast_ids into the tracker so mid-session stream restarts don't leave heartbeats on a stale ID
- the GQL Watcher keeps running — still useful for its `DropCurrentSessionContext` progress polling; its heartbeat is harmless

**`internal/points/rotation.go` — slot reservation:**
- rotation reserves one of the two heartbeat slots while a pick is active, and `ApplyPick` kicks rotation before claiming it, so the pick's `StartWatching` can't fail on capacity when both slots are occupied by points channels

## Verification

Before the fix, a dozen fresh picks in a row got zero credit over ~4 hours (sessions nil or frozen). Immediately after deploying it on my live instance (Raspberry Pi, arm64), fresh picks credited 1 minute per minute again and completed + auto-claimed their drops. `go build` / `go vet` are clean; the four failing selector tests in `internal/drops` fail identically on unmodified `main` (date-dependent fixtures, unrelated).

## Credit

The payload requirements were independently confirmed by INKCR0W/TwitchDropsMinerGo commits `f590d9b` ("send minute-watched directly to spade instead of GQL") and `63b3287` ("send game/game_id in spade minute-watched so Twitch credits watch time"), both from July 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch drop and channel-point credit tracking during channel switching and watcher rotation.
  * Preserved drop-credit capacity when prioritizing channels for monitoring.
  * Updated heartbeat data with current broadcast and game details to improve credit attribution.
  * Added safer handling when monitoring capacity is unavailable for a newly selected channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->