### PR TITLE
fix(drops): don't mark shared-benefit campaigns falsely completed (#7)

### DIFF
--- a/internal/twitch/drops.go
+++ b/internal/twitch/drops.go
@@ -100,6 +100,77 @@ func (d *TimeBasedDrop) IsComplete() bool {
 	return d.RequiredMinutesWatched > 0 && d.CurrentMinutesWatched >= d.RequiredMinutesWatched
 }
 
+// applyClaimedBenefitFallback marks a campaign's drops as claimed based on
+// the account's gameEventDrops benefit-award history. This is a fallback:
+// after a fresh claim Twitch's dashboard sometimes keeps reporting
+// `self.isClaimed=false` for a few seconds to minutes (the same lag window
+// where getCurrentDropSession returns nil), so the bot would otherwise
+// re-pick a campaign whose drop is actually already claimed.
+// gameEventDrops is the permanent benefit-award history and reflects the
+// claim immediately.
+//
+// The award signal is only trustworthy under three guards — without them
+// it false-positives whole campaigns as "fully claimed" and the selector
+// skips them (GitHub issue #7):
+//
+//  1. Time window: the award (lastAwardedAt) must fall inside the drop's
+//     [StartAt, EndAt) window (campaign window when the drop has none).
+//     Otherwise a daily-rolling drop is marked claimed because yesterday's
+//     instance was awarded under the same benefit ID.
+//
+//  2. Completion: a drop below 100% cannot have been claimed — Twitch only
+//     issues a claimable DropInstanceID at completion. Marking a
+//     mid-progress drop (e.g. 62%) claimed is always wrong.
+//
+//  3. Benefit uniqueness: when several drops in the SAME campaign share one
+//     benefit ID (e.g. R6S "Esports Pack" awarded at 5 escalating watch
+//     tiers), a single award can't tell us WHICH tier was claimed. The
+//     signal is ambiguous, so skip it and trust the inventory's per-drop
+//     isClaimed instead. This is the exact shape that triggered issue #7.
+func applyClaimedBenefitFallback(c *DropCampaign, claimedBenefits map[string]time.Time) {
+	// Count benefit-ID occurrences within this campaign so guard 3 can
+	// detect the ambiguous many-drops-one-benefit case.
+	benefitCount := make(map[string]int)
+	for i := range c.Drops {
+		if bid := c.Drops[i].BenefitID; bid != "" {
+			benefitCount[bid]++
+		}
+	}
+
+	for j := range c.Drops {
+		drop := &c.Drops[j]
+		if drop.IsClaimed || drop.BenefitID == "" {
+			continue
+		}
+		if !drop.IsComplete() {
+			continue // guard 2: below 100% can't have been claimed
+		}
+		if benefitCount[drop.BenefitID] > 1 {
+			continue // guard 3: shared benefit ID — award is ambiguous
+		}
+		awarded, ok := claimedBenefits[drop.BenefitID]
+		if !ok {
+			continue
+		}
+		// guard 1: award must fall inside the drop's own window. Without
+		// per-drop windows, fall back to the campaign window.
+		start := drop.StartAt
+		end := drop.EndAt
+		if start.IsZero() {
+			start = c.StartAt
+		}
+		if end.IsZero() {
+			end = c.EndAt
+		}
+		if start.IsZero() || end.IsZero() {
+			continue // no window to check, keep dashboard truth
+		}
+		if (awarded.Equal(start) || awarded.After(start)) && awarded.Before(end) {
+			drop.IsClaimed = true
+		}
+	}
+}
+
 // ProgressPercent returns the drop progress as a percentage (0-100).
 func (d *TimeBasedDrop) ProgressPercent() int {
 	if d.RequiredMinutesWatched <= 0 {
@@ -229,52 +300,9 @@ func (g *GQLClient) GetDropsInventory() ([]DropCampaign, error) {
 			}
 		}
 
-		// Step 4: gameEventDrops claim-detection fallback, time-window
-		// scoped. After a recent claim Twitch's dashboard sometimes
-		// keeps reporting `self.isClaimed=false` for a few seconds to
-		// minutes (the same window where getCurrentDropSession returns
-		// nil), so the bot otherwise re-picks a campaign whose drop
-		// is actually already claimed. gameEventDrops is the
-		// permanent benefit-award history and reflects the claim
-		// immediately.
-		//
-		// The v1.8.0 regression we're avoiding: marking a daily-
-		// rolling drop (Marble Day, etc.) as already-claimed because
-		// yesterday's instance was awarded under the same benefit ID.
-		// Fix: only honour the fallback when lastAwardedAt is inside
-		// THIS drop's [StartAt, EndAt) window. That ties the claim
-		// signal to the actual instance, not the benefit ID alone —
-		// matches TDM's approach (src/models/drop.py:49 reads
-		// gameEventDrops timestamp and compares against the drop's
-		// own period).
-		for j := range dashboardCampaigns[i].Drops {
-			drop := &dashboardCampaigns[i].Drops[j]
-			if drop.IsClaimed || drop.BenefitID == "" {
-				continue
-			}
-			awarded, ok := claimedBenefits[drop.BenefitID]
-			if !ok {
-				continue
-			}
-			// If the drop has explicit per-drop windows, the award
-			// must fall inside [StartAt, EndAt). Without windows,
-			// fall back to the campaign window so daily-rolling
-			// campaigns don't false-positive.
-			start := drop.StartAt
-			end := drop.EndAt
-			if start.IsZero() {
-				start = dashboardCampaigns[i].StartAt
-			}
-			if end.IsZero() {
-				end = dashboardCampaigns[i].EndAt
-			}
-			if start.IsZero() || end.IsZero() {
-				continue // no window to check, keep dashboard truth
-			}
-			if (awarded.Equal(start) || awarded.After(start)) && awarded.Before(end) {
-				drop.IsClaimed = true
-			}
-		}
+		// Step 4: gameEventDrops claim-detection fallback (see
+		// applyClaimedBenefitFallback for the full rationale + guards).
+		applyClaimedBenefitFallback(&dashboardCampaigns[i], claimedBenefits)
 	}
 
 	// Step 5: union with Inventory campaigns that the Dashboard summary

--- a/internal/twitch/drops_test.go
+++ b/internal/twitch/drops_test.go
@@ -1,0 +1,126 @@
+package twitch
+
+import (
+	"testing"
+	"time"
+)
+
+// campaignWindow is a fixed [start, end) used by the fallback tests.
+var (
+	campStart  = time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC)
+	campEnd    = time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	awardInWin = time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC)
+)
+
+// TestApplyClaimedBenefitFallback_SharedBenefitIncompleteNotClaimed is the
+// GitHub issue #7 regression: a campaign whose drops all share ONE benefit
+// ID at escalating watch tiers (R6S "Esports Pack 2026 S1.2"), none of them
+// at 100%, must NOT be marked claimed just because that benefit was awarded
+// once inside the campaign window. Before the fix, all tiers flipped to
+// IsClaimed=true and the campaign was falsely marked fully completed.
+func TestApplyClaimedBenefitFallback_SharedBenefitIncompleteNotClaimed(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "esports-pack", RequiredMinutesWatched: 540, CurrentMinutesWatched: 335}, // 62%
+			{ID: "d2", BenefitID: "esports-pack", RequiredMinutesWatched: 720, CurrentMinutesWatched: 0},   // 0%
+			{ID: "d3", BenefitID: "esports-pack", RequiredMinutesWatched: 540, CurrentMinutesWatched: 448}, // 83%
+		},
+	}
+	claimed := map[string]time.Time{"esports-pack": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	for _, d := range c.Drops {
+		if d.IsClaimed {
+			t.Fatalf("drop %s (%d/%d) wrongly marked claimed by shared-benefit award",
+				d.ID, d.CurrentMinutesWatched, d.RequiredMinutesWatched)
+		}
+	}
+}
+
+// TestApplyClaimedBenefitFallback_SharedBenefitAllCompleteStillAmbiguous:
+// even when the shared-benefit tiers are ALL at 100%, a single award can't
+// prove every tier was claimed, so the ambiguous signal is ignored (guard 3).
+// Inventory's per-drop isClaimed remains the source of truth.
+func TestApplyClaimedBenefitFallback_SharedBenefitAllCompleteStillAmbiguous(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "esports-pack", RequiredMinutesWatched: 540, CurrentMinutesWatched: 540},
+			{ID: "d2", BenefitID: "esports-pack", RequiredMinutesWatched: 720, CurrentMinutesWatched: 720},
+		},
+	}
+	claimed := map[string]time.Time{"esports-pack": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	for _, d := range c.Drops {
+		if d.IsClaimed {
+			t.Fatalf("drop %s wrongly marked claimed — one award can't cover multiple shared-benefit tiers", d.ID)
+		}
+	}
+}
+
+// TestApplyClaimedBenefitFallback_UniqueCompleteClaimed is the legitimate
+// case the fallback exists for: a single unique-benefit drop at 100% whose
+// benefit was awarded inside the window (dashboard just lagging isClaimed).
+// It must be recognised as claimed.
+func TestApplyClaimedBenefitFallback_UniqueCompleteClaimed(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "unique-badge", RequiredMinutesWatched: 60, CurrentMinutesWatched: 60},
+		},
+	}
+	claimed := map[string]time.Time{"unique-badge": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	if !c.Drops[0].IsClaimed {
+		t.Fatal("unique complete drop with in-window award should be marked claimed")
+	}
+}
+
+// TestApplyClaimedBenefitFallback_UniqueIncompleteNotClaimed: a unique-benefit
+// drop below 100% can't have been claimed even if the benefit shows an award
+// (e.g. a stale/cross-campaign award) — guard 2.
+func TestApplyClaimedBenefitFallback_UniqueIncompleteNotClaimed(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "unique-badge", RequiredMinutesWatched: 60, CurrentMinutesWatched: 30},
+		},
+	}
+	claimed := map[string]time.Time{"unique-badge": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	if c.Drops[0].IsClaimed {
+		t.Fatal("incomplete drop (30/60) must not be marked claimed")
+	}
+}
+
+// TestApplyClaimedBenefitFallback_AwardOutsideWindow: a unique complete drop
+// whose only award predates the campaign window must not be marked claimed
+// (guard 1 — daily-rolling protection).
+func TestApplyClaimedBenefitFallback_AwardOutsideWindow(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "unique-badge", RequiredMinutesWatched: 60, CurrentMinutesWatched: 60},
+		},
+	}
+	claimed := map[string]time.Time{"unique-badge": campStart.Add(-48 * time.Hour)}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	if c.Drops[0].IsClaimed {
+		t.Fatal("award before the campaign window must not mark the drop claimed")
+	}
+}


### PR DESCRIPTION
Fixes #7.

## Bug
A campaign was marked `fully claimed` and skipped while its drops were still in progress. Reporter's case: **R6S S1 2026 11** — 5 drops, all named *Esports Pack 2026 S1.2* (same benefit, escalating watch tiers 9h/12h/…), none at 100% (one at 62%, one at 83%), yet the bot logged `Campaign "R6S S1 2026 11" fully claimed — marked as completed`.

## Root cause
The `gameEventDrops` claim-detection fallback in `internal/twitch/drops.go` matched purely on `BenefitID` against the campaign window. Because all 5 tiers share one `BenefitID`, a single award timestamp inside the window flipped **every** tier to `IsClaimed=true`. `autoClaimWith` then saw `allClaimed=true` and marked the campaign completed → selector skips it.

## Fix
Extracted the fallback into `applyClaimedBenefitFallback` with two guards added beyond the existing time-window check:

1. **Completion** — a drop below 100% cannot have been claimed (Twitch only issues a claimable instance at completion). A 62% drop is never `claimed`.
2. **Benefit uniqueness** — when multiple drops in one campaign share a `BenefitID`, a single award can't identify which tier was claimed. The signal is ambiguous, so it's ignored and inventory's per-drop `isClaimed` stays authoritative.

The legitimate case the fallback exists for (a unique-benefit drop at 100% whose dashboard `isClaimed` is lagging) still works.

## Tests
New `internal/twitch/drops_test.go`:
- issue-#7 shape: shared-benefit tiers below 100% → not claimed ✅
- shared-benefit tiers all at 100% → still ambiguous, not claimed ✅
- unique complete drop, in-window award → claimed (lag case preserved) ✅
- unique incomplete drop → not claimed ✅
- award before window → not claimed (daily-rolling protection) ✅

`go build` / `go vet` clean; `internal/twitch` tests pass. The 4 `internal/drops/selector_test.go` failures are pre-existing date-fixture failures (documented in #4), unrelated — this change is confined to `internal/twitch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved claimed-drop detection when award records are used as a fallback.
  * Drops are now marked claimed only when they are complete and the award occurred within the applicable campaign or drop window.
  * Prevented ambiguous claims when multiple drops share the same benefit.
* **Tests**
  * Added regression coverage for shared benefits, incomplete drops, unique claims, and awards outside campaign windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->