### PR TITLE
fix(drops): keep drop-row Percent/ETA consistent with progress

### DIFF
--- a/internal/drops/progress.go
+++ b/internal/drops/progress.go
@@ -246,17 +246,10 @@ func (s *Service) ApplyProgressUpdate(data twitch.DropProgressData) {
 			s.activeDrops[i].Required = resolvedRequired
 		}
 		s.activeDrops[i].Progress = data.CurrentMinutesWatched
-		if s.activeDrops[i].Required > 0 {
-			pct := (data.CurrentMinutesWatched * 100) / s.activeDrops[i].Required
-			if pct > 100 {
-				pct = 100
-			}
-			s.activeDrops[i].Percent = pct
-			s.activeDrops[i].EtaMinutes = s.activeDrops[i].Required - data.CurrentMinutesWatched
-			if s.activeDrops[i].EtaMinutes < 0 {
-				s.activeDrops[i].EtaMinutes = 0
-			}
-		}
+		// Percent + EtaMinutes are derived from Progress/Required — always
+		// recompute them together so the row can't show a stale percentage
+		// next to fresh minutes (the "248/300min (88%)" display bug).
+		s.activeDrops[i].recomputeDerived()
 		updated = true
 		break
 	}

--- a/internal/drops/rows.go
+++ b/internal/drops/rows.go
@@ -190,31 +190,44 @@ func campaignToRow(c twitch.DropCampaign, pinnedID string) ActiveDrop {
 		break
 	}
 
-	pct := 0
-	if required > 0 {
-		pct = (progress * 100) / required
-		if pct > 100 {
-			pct = 100
-		}
-	}
-
-	eta := required - progress
-	if eta < 0 {
-		eta = 0
-	}
-
-	return ActiveDrop{
+	row := ActiveDrop{
 		CampaignID:         c.ID,
 		CampaignName:       c.Name,
 		GameName:           c.GameName,
 		DropName:           dropName,
 		Progress:           progress,
 		Required:           required,
-		Percent:            pct,
 		EndAt:              c.EndAt,
 		IsEnabled:          true,
 		IsAccountConnected: c.IsAccountConnected,
 		IsPinned:           c.ID == pinnedID && pinnedID != "",
-		EtaMinutes:         eta,
 	}
+	row.recomputeDerived()
+	return row
+}
+
+// recomputeDerived recalculates Percent and EtaMinutes from Progress and
+// Required. Both are pure functions of those two fields, so storing them
+// independently invites divergence: a progress event that advances
+// Progress without recomputing Percent/EtaMinutes (e.g. when Required was
+// momentarily 0) leaves the row showing a stale "248/300min (88%)" where
+// the percentage no longer matches the minutes. Every writer of Progress
+// or Required MUST call this before the row is published so the three
+// fields can never disagree on screen.
+func (d *ActiveDrop) recomputeDerived() {
+	if d.Required <= 0 {
+		d.Percent = 0
+		d.EtaMinutes = 0
+		return
+	}
+	pct := (d.Progress * 100) / d.Required
+	if pct > 100 {
+		pct = 100
+	}
+	d.Percent = pct
+	eta := d.Required - d.Progress
+	if eta < 0 {
+		eta = 0
+	}
+	d.EtaMinutes = eta
 }

--- a/internal/drops/rows_progress_test.go
+++ b/internal/drops/rows_progress_test.go
@@ -1,0 +1,121 @@
+package drops
+
+import (
+	"testing"
+
+	"github.com/miwi/twitchpoint/internal/config"
+	"github.com/miwi/twitchpoint/internal/twitch"
+)
+
+// assertConsistent fails if Percent / EtaMinutes don't match what
+// Progress and Required imply. This is the invariant the display bug
+// violated ("248/300min (88%)" — percentage out of sync with minutes).
+func assertConsistent(t *testing.T, d ActiveDrop) {
+	t.Helper()
+	wantPct := 0
+	wantEta := 0
+	if d.Required > 0 {
+		wantPct = (d.Progress * 100) / d.Required
+		if wantPct > 100 {
+			wantPct = 100
+		}
+		wantEta = d.Required - d.Progress
+		if wantEta < 0 {
+			wantEta = 0
+		}
+	}
+	if d.Percent != wantPct {
+		t.Fatalf("Percent %d inconsistent with %d/%d (want %d)", d.Percent, d.Progress, d.Required, wantPct)
+	}
+	if d.EtaMinutes != wantEta {
+		t.Fatalf("EtaMinutes %d inconsistent with %d/%d (want %d)", d.EtaMinutes, d.Progress, d.Required, wantEta)
+	}
+}
+
+func TestRecomputeDerived(t *testing.T) {
+	cases := []struct {
+		progress, required, wantPct, wantEta int
+	}{
+		{248, 300, 82, 52},
+		{300, 300, 100, 0},
+		{330, 300, 100, 0}, // over 100% clamps, eta floors at 0
+		{0, 300, 0, 300},
+		{50, 0, 0, 0}, // no required → both zeroed, never a stale percentage
+	}
+	for _, c := range cases {
+		d := ActiveDrop{Progress: c.progress, Required: c.required}
+		d.recomputeDerived()
+		if d.Percent != c.wantPct || d.EtaMinutes != c.wantEta {
+			t.Fatalf("progress=%d required=%d → pct=%d eta=%d, want pct=%d eta=%d",
+				c.progress, c.required, d.Percent, d.EtaMinutes, c.wantPct, c.wantEta)
+		}
+	}
+}
+
+// TestApplyProgressUpdate_KeepsPercentConsistent is the display-bug
+// regression: a progress event that advances Progress must recompute
+// Percent/EtaMinutes so they can never be left stale. Seed the row with a
+// deliberately wrong (stale) Percent to prove the update overwrites it.
+func TestApplyProgressUpdate_KeepsPercentConsistent(t *testing.T) {
+	s := &Service{
+		cfg:           &config.Config{},
+		log:           func(string, ...interface{}) {},
+		writeLogFile:  func(string) {},
+		campaignCache: map[string]twitch.DropCampaign{},
+		activeDrops: []ActiveDrop{{
+			CampaignID: "camp-1",
+			Progress:   248,
+			Required:   300,
+			Percent:    88, // stale/wrong on purpose (248/300 = 82%)
+			EtaMinutes: 120, // stale/wrong on purpose (300-248 = 52)
+		}},
+	}
+
+	s.ApplyProgressUpdate(twitch.DropProgressData{
+		CampaignID:            "camp-1",
+		DropID:                "drop-1",
+		CurrentMinutesWatched: 250,
+		// RequiredMinutesWatched intentionally 0: the payload often omits
+		// it, which is exactly when the old code skipped the Percent/Eta
+		// recompute and left the stale values on screen.
+	})
+
+	assertConsistent(t, s.activeDrops[0])
+	if s.activeDrops[0].Progress != 250 {
+		t.Fatalf("Progress not advanced: got %d", s.activeDrops[0].Progress)
+	}
+	if s.activeDrops[0].Percent != 83 { // 250/300
+		t.Fatalf("Percent not refreshed from advanced progress: got %d", s.activeDrops[0].Percent)
+	}
+}
+
+// TestApplyProgressUpdate_RequiredResolvedFromPayload: when the payload
+// carries a required value, it's adopted and the derived fields follow it.
+func TestApplyProgressUpdate_RequiredResolvedFromPayload(t *testing.T) {
+	s := &Service{
+		cfg:           &config.Config{},
+		log:           func(string, ...interface{}) {},
+		writeLogFile:  func(string) {},
+		campaignCache: map[string]twitch.DropCampaign{},
+		activeDrops: []ActiveDrop{{
+			CampaignID: "camp-1",
+			Progress:   10,
+			Required:   60,
+			Percent:    16,
+			EtaMinutes: 50,
+		}},
+	}
+
+	s.ApplyProgressUpdate(twitch.DropProgressData{
+		CampaignID:             "camp-1",
+		DropID:                 "drop-2",
+		CurrentMinutesWatched:  30,
+		RequiredMinutesWatched: 120,
+	})
+
+	assertConsistent(t, s.activeDrops[0])
+	if s.activeDrops[0].Required != 120 || s.activeDrops[0].Percent != 25 {
+		t.Fatalf("expected Required=120 Percent=25, got Required=%d Percent=%d",
+			s.activeDrops[0].Required, s.activeDrops[0].Percent)
+	}
+}


### PR DESCRIPTION
## Bug
The drops tab could show a percentage out of sync with the minutes — e.g. **`248/300min (88%)`** (248/300 is 82%, not 88%), with an ETA that matched neither. Purely a display defect: drop credit itself was working.

## Root cause
`ActiveDrop.Percent` and `ActiveDrop.EtaMinutes` are pure functions of `Progress` and `Required`, but they were **stored independently** and updated out of lockstep. In `ApplyProgressUpdate`, `Progress` was advanced on every WS event, but `Percent`/`EtaMinutes` were only recomputed `if Required > 0`. A progress event arriving while `Required` was momentarily 0 (the payload often omits it) advanced the minutes and left the percentage/ETA frozen at their previous values.

## Fix
Single source of truth: `ActiveDrop.recomputeDerived()` recomputes `Percent` and `EtaMinutes` from `Progress`/`Required` (clamped), and it's called after every write of either field — both the `campaignToRow` build path and `ApplyProgressUpdate`. The three fields can no longer disagree.

## Tests
New `rows_progress_test.go`:
- `recomputeDerived` across normal / 100% / over-100% / zero-progress / no-required cases
- `ApplyProgressUpdate` overwrites a deliberately-stale Percent/ETA when a required-omitted payload advances progress (the exact bug shape)
- `ApplyProgressUpdate` adopts a payload-provided required and keeps derived fields consistent

`go build` / `go vet` clean. The 4 `selector_test.go` failures are pre-existing date-fixture failures, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drop progress calculations so completion percentages and estimated remaining time stay accurate as viewing progress updates.
  * Corrected progress displays when required viewing time is missing, changes, or when progress exceeds the required amount.
* **Tests**
  * Added coverage for normal, zero-progress, zero-requirement, and over-completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->