### PR TITLE
fix(drops): don't re-farm campaigns Twitch zeroed after awarding (guard 2 regression)

### DIFF
--- a/internal/twitch/drops.go
+++ b/internal/twitch/drops.go
@@ -118,9 +118,14 @@ func (d *TimeBasedDrop) IsComplete() bool {
 //     Otherwise a daily-rolling drop is marked claimed because yesterday's
 //     instance was awarded under the same benefit ID.
 //
-//  2. Completion: a drop below 100% cannot have been claimed — Twitch only
-//     issues a claimable DropInstanceID at completion. Marking a
-//     mid-progress drop (e.g. 62%) claimed is always wrong.
+//  2. Partial progress: a drop with 0 < watched < required is genuinely
+//     mid-progress and cannot have been claimed — marking it (e.g. 62%)
+//     claimed is always wrong. watched==0 is EXEMPT: after Twitch
+//     auto-grants a reward it zeroes the campaign's currentMinutesWatched
+//     (and leaves isClaimed=false, dropInstanceID=null), so a fully farmed
+//     drop is byte-for-byte identical to a never-watched one. The in-window
+//     award is then the only evidence the reward is already owned; guards 1
+//     and 3 gate that signal, so we must not swallow it here.
 //
 //  3. Benefit uniqueness: when several drops in the SAME campaign share one
 //     benefit ID (e.g. R6S "Esports Pack" awarded at 5 escalating watch
@@ -142,8 +147,8 @@ func applyClaimedBenefitFallback(c *DropCampaign, claimedBenefits map[string]tim
 		if drop.IsClaimed || drop.BenefitID == "" {
 			continue
 		}
-		if !drop.IsComplete() {
-			continue // guard 2: below 100% can't have been claimed
+		if drop.CurrentMinutesWatched > 0 && !drop.IsComplete() {
+			continue // guard 2: partial progress can't have been claimed (watched==0 exempt — see doc)
 		}
 		if benefitCount[drop.BenefitID] > 1 {
 			continue // guard 3: shared benefit ID — award is ambiguous

--- a/internal/twitch/drops_test.go
+++ b/internal/twitch/drops_test.go
@@ -124,3 +124,51 @@ func TestApplyClaimedBenefitFallback_AwardOutsideWindow(t *testing.T) {
 		t.Fatal("award before the campaign window must not mark the drop claimed")
 	}
 }
+
+// TestApplyClaimedBenefitFallback_ZeroedCounterAfterAward: Twitch zeroes the
+// campaign counter after auto-granting a reward, so a fully farmed drop reports
+// watched=0 with isClaimed=false. The in-window award is the only remaining
+// evidence that the reward is already owned — guard 2 must not swallow it, or
+// the bot re-farms an already-owned campaign forever (progress stuck at 0/0).
+func TestApplyClaimedBenefitFallback_ZeroedCounterAfterAward(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "unique-badge", RequiredMinutesWatched: 900, CurrentMinutesWatched: 0},
+		},
+	}
+	claimed := map[string]time.Time{"unique-badge": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	if !c.Drops[0].IsClaimed {
+		t.Fatal("zeroed-counter drop with in-window award should be marked claimed")
+	}
+}
+
+// TestApplyClaimedBenefitFallback_NeverWatchedNoAward: a never-watched drop
+// (watched=0) whose benefit has NO award must stay open — the watched==0
+// exemption must not mark drops the account doesn't own. Guards the case of a
+// partially-farmed campaign whose later tiers aren't earned yet.
+func TestApplyClaimedBenefitFallback_NeverWatchedNoAward(t *testing.T) {
+	c := &DropCampaign{
+		StartAt: campStart,
+		EndAt:   campEnd,
+		Drops: []TimeBasedDrop{
+			{ID: "d1", BenefitID: "earned-badge", RequiredMinutesWatched: 60, CurrentMinutesWatched: 0},
+			{ID: "d2", BenefitID: "unearned-badge", RequiredMinutesWatched: 900, CurrentMinutesWatched: 0},
+		},
+	}
+	// Only d1's benefit was awarded; d2 has no award entry.
+	claimed := map[string]time.Time{"earned-badge": awardInWin}
+
+	applyClaimedBenefitFallback(c, claimed)
+
+	if !c.Drops[0].IsClaimed {
+		t.Fatal("d1 (awarded in-window) should be marked claimed")
+	}
+	if c.Drops[1].IsClaimed {
+		t.Fatal("d2 (no award) must stay open so the campaign keeps farming")
+	}
+}


### PR DESCRIPTION
## Bug
After Twitch auto-grants a drop reward it resets the campaign's `self.currentMinutesWatched` to **0** while leaving `self.isClaimed=false` and `dropInstanceID=null`. A fully farmed campaign then looks byte-for-byte identical to an untouched one.

`applyClaimedBenefitFallback` (added in v2.1.5, #8) is the mechanism meant to resolve this via `gameEventDrops`, but **guard 2** returned early before the award was ever consulted:

```go
if !drop.IsComplete() { continue } // IsComplete needs watched >= required
```

With `watched == 0`, `IsComplete()` is false, so the already-owned campaign was re-picked forever. The stall detector then churned channels (observed: 8 channels in 22 min, all `no credit … progress stuck at 0/0`) — correctly, since there was nothing left to award.

Observed twice: a 10-tier *Dark and Darker* campaign (all tiers awarded, all reset to watched=0) and a single-drop *PUBG EWC D3* campaign.

## Fix
Exempt `watched == 0` from guard 2:
```go
if drop.CurrentMinutesWatched > 0 && !drop.IsComplete() { continue }
```
- `0 < watched < required` → genuine mid-progress → still blocked (issue #7 shape)
- `watched == 0` → never-watched **or** zeroed-after-award; guards 1 (award in window) and 3 (shared benefit ID ambiguous) decide

**Issue #7 stays fixed:** R6S "Esports Pack" shares one benefit ID across tiers → guard 3 short-circuits the zeroed tiers; partial-progress tiers are still caught by the amended guard 2. A never-watched drop can only pass if its **unique** benefit shows an **in-window** award — i.e. the account genuinely owns it.

## Tests
All 5 existing fallback tests stay green (the `watched=30` incomplete case is still blocked). Two added:
- `ZeroedCounterAfterAward` — watched=0 + in-window award → marked claimed
- `NeverWatchedNoAward` — watched=0 + no award → stays open (campaign keeps farming)

`go build` / `go vet` clean; `internal/twitch` tests pass.

Thanks to the reporter for the precise root-cause analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drop claim detection when watch-time counters reset after an award.
  * Prevented in-progress drops from being incorrectly marked as claimed.
  * Preserved correct handling for drops that have never been watched, allowing later rewards to continue progressing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->