### PR TITLE
fix: repair silently failing selector tests, guard premature campaign completion, build for the target arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+# --platform=$BUILDPLATFORM keeps the toolchain running natively on the build
+# host; the Go cross-compiler produces the target binary, so no emulation is
+# needed when building for a foreign architecture.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /app
 
@@ -10,8 +13,13 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o twitchpoint ./cmd/twitchpoint
+# Build binary for the requested target platform. TARGETOS/TARGETARCH are
+# provided automatically by BuildKit; the defaults keep the previous behaviour
+# for builders that don't set them.
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -ldflags="-s -w" -o twitchpoint ./cmd/twitchpoint
 
 # Runtime stage
 FROM alpine:3.21

--- a/internal/drops/inventory.go
+++ b/internal/drops/inventory.go
@@ -67,6 +67,7 @@ func (s *Service) autoClaimWith(campaigns []twitch.DropCampaign, claimer dropCla
 
 		allClaimed := true
 		hasWatchable := false
+		claimedSeen := 0
 		for di := range c.Drops {
 			d := &c.Drops[di]
 			if d.RequiredMinutesWatched <= 0 {
@@ -74,6 +75,7 @@ func (s *Service) autoClaimWith(campaigns []twitch.DropCampaign, claimer dropCla
 			}
 			hasWatchable = true
 			if d.IsClaimed {
+				claimedSeen++
 				continue
 			}
 			if d.IsComplete() && d.DropInstanceID != "" {
@@ -97,6 +99,7 @@ func (s *Service) autoClaimWith(campaigns []twitch.DropCampaign, claimer dropCla
 					// stages (Selector, SnapshotPick) see the fresh
 					// claim without another inventory round-trip.
 					d.IsClaimed = true
+					claimedSeen++
 				}
 			} else {
 				// Drop is unclaimed AND not complete (or no instance
@@ -105,7 +108,26 @@ func (s *Service) autoClaimWith(campaigns []twitch.DropCampaign, claimer dropCla
 			}
 		}
 
-		if hasWatchable && allClaimed {
+		// Guard against premature completion. Twitch sometimes omits
+		// requiredMinutesWatched for a campaign's LATER drops, so the loop
+		// above sees "everything watchable is claimed" while drops 4 and 5
+		// are still ahead — the campaign is then filtered as completed
+		// forever and the remaining drops are abandoned mid-progress
+		// (observed on a 5-tier Marble Day campaign).
+		//
+		// Two extra conditions make the signal trustworthy:
+		//   - !InInventory: while Twitch still lists the campaign as
+		//     in-progress there is more to farm. Same anchor
+		//     MarkCompletedIfFinishedExternally already relies on.
+		//   - claimedSeen > 0: a campaign whose metadata glitched to
+		//     "no watchable drops" must not complete itself without a
+		//     single observed claim.
+		//
+		// A campaign that is genuinely finished but still in the inventory
+		// is simply re-evaluated next cycle; the selector already skips it
+		// because no drop reports IsEarnable, so it cannot cause a farming
+		// loop in the meantime.
+		if hasWatchable && allClaimed && claimedSeen > 0 && !c.InInventory {
 			s.cfg.MarkCampaignCompleted(c.ID)
 			_ = s.cfg.Save()
 			s.log("[Drops] Campaign %q fully claimed — marked as completed", c.Name)

--- a/internal/drops/selector_test.go
+++ b/internal/drops/selector_test.go
@@ -131,16 +131,30 @@ func TestFilterEligibleCampaigns(t *testing.T) {
 // fakeStreamSource is a deterministic in-memory stream source for tests.
 type fakeStreamSource struct {
 	byGame  map[string][]twitch.GameStream
-	calls   map[string]int                     // game name → how often queried
+	calls   map[string]int                     // fixture key (display name) → how often queried
 	byLogin map[string]*twitch.ChannelInfo     // login → ChannelInfo for ACL lookups
 }
 
-func (f *fakeStreamSource) GetGameStreamsDropsEnabled(gameName string, limit int) ([]twitch.GameStream, error) {
+// GetGameStreamsDropsEnabled receives the game's URL slug — since the v2.0
+// persisted-hash GameDirectory switch, production queries the directory by
+// slug, not display name. Fixtures stay keyed by display name for
+// readability; the fake resolves the slug back to the fixture key (and
+// counts the call under it) so assertions can keep using display names.
+func (f *fakeStreamSource) GetGameStreamsDropsEnabled(gameSlug string, limit int) ([]twitch.GameStream, error) {
 	if f.calls == nil {
 		f.calls = make(map[string]int)
 	}
-	f.calls[gameName]++
-	streams := f.byGame[gameName]
+	key := gameSlug
+	streams, ok := f.byGame[key]
+	if !ok {
+		for name, s := range f.byGame {
+			if twitch.SlugFromGameName(name) == gameSlug {
+				key, streams = name, s
+				break
+			}
+		}
+	}
+	f.calls[key]++
 	if len(streams) > limit {
 		return streams[:limit], nil
 	}


### PR DESCRIPTION
Three independent fixes I've been carrying downstream while running this on a
Raspberry Pi. Separate commits, so feel free to take them individually.

### 1. `fix(test)`: four selector tests have been failing silently

Since the v2.0 switch to the persisted-hash `GameDirectory` query, production
passes the game's **URL slug** to `GetGameStreamsDropsEnabled`, while the test
fixtures in `selector_test.go` are keyed by **display name**. The fake source
returns no streams, `buildPool` produces an empty pool, and four tests fail:

- `TestBuildPool_UnrestrictedCampaign`
- `TestBuildPool_DirectoryQueriedOncePerGame`
- `TestSelect_WantedGamesForcesNonClosestExpiry`
- `TestSelect_SkipChannelsExcludesFromPool`

`go test ./...` on current `main` reproduces this. `fakeStreamSource` now falls
back to matching `SlugFromGameName(fixtureKey)` against the requested slug and
counts the call under the fixture key, so the "queried once per game"
assertion keeps working. Fixtures stay readable, no production code touched.

**After this commit `go test ./...` is green again.**

### 2. `fix(drops)`: campaign marked completed while it still had drops left

`autoClaimWith()` wrote a campaign to `completed_campaigns` as soon as every
drop it could see was claimed. Twitch sometimes omits
`requiredMinutesWatched` for a campaign's later drops, so after claiming drop
3 of 5 the loop concludes "everything claimed", the campaign is filtered out
permanently, and the remaining two drops are abandoned mid-progress. Observed
here on a 5-tier Marble Day campaign.

Completion now additionally requires:

- `!c.InInventory` — while Twitch still lists the campaign as in-progress
  there is more to farm. This is the same anchor
  `MarkCompletedIfFinishedExternally` already trusts, so both paths now agree.
- `claimedSeen > 0` — a campaign whose metadata glitched to "nothing
  watchable" can't complete itself without a single observed claim.

No farming loop is introduced by waiting: a genuinely finished campaign that's
still in the inventory is skipped by the selector anyway (no drop reports
`IsEarnable`) and gets marked on a later cycle once Twitch drops it from the
in-progress list.

### 3. `build`: image only ever built for amd64

The Dockerfile hard-codes `GOARCH=amd64`, so the image can't run on arm64 —
Raspberry Pi, Apple Silicon, arm64 VPS. The release workflow already ships a
`twitchpoint-linux-arm64` binary, so the Docker image was the last place still
pinned. I've been patching this line locally on every update.

`GOOS`/`GOARCH` now come from `TARGETOS`/`TARGETARCH`, which BuildKit sets
automatically, with `${VAR:-…}` defaults so nothing changes for existing
builds:

| build command | result |
|---|---|
| `docker build` on x86-64 | `amd64` — unchanged |
| builder that sets neither var | falls back to `linux/amd64` |
| `docker build` on arm64 | native arm64 image |
| `docker buildx build --platform linux/amd64,linux/arm64` | multi-arch image |

The builder stage is pinned to `--platform=$BUILDPLATFORM` so the Go toolchain
keeps running natively and cross-compiles, rather than the whole build stage
being emulated through QEMU (painfully slow for Go).

### Testing

- `go test ./...` — green with commit 1 (red on `main` before it)
- `go build ./...` — clean
- Built and deployed as an arm64 image on a Pi 4 (Debian 13); v2.1.7 running
  with these three commits, drops and points mining working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign completion detection to avoid marking campaigns complete when drop information is incomplete or inconsistent.
  * Improved multi-architecture container builds, supporting binaries for different operating systems and CPU architectures while preserving existing defaults.

* **Tests**
  * Updated stream-selection test coverage to reflect game slug-based lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->