### PR TITLE
feat: surface why a wanted-game campaign isn't being farmed

### DIFF
--- a/internal/drops/rows.go
+++ b/internal/drops/rows.go
@@ -31,10 +31,40 @@ type ActiveDrop struct {
 	// is non-empty (with an empty list, ALL eligible campaigns are
 	// auto-discovered and the marker would be noise).
 	IsAutoDiscovered bool `json:"is_auto_discovered"`
-	Status             string    `json:"status"`               // ACTIVE / QUEUED / IDLE / DISABLED / COMPLETED
+	Status             string    `json:"status"`               // ACTIVE / QUEUED / IDLE / DISABLED / COMPLETED / BLOCKED
+	// BlockReason explains a BLOCKED status in one short phrase
+	// ("account not linked", …) so the UI can show WHY a wanted-game
+	// campaign isn't being farmed instead of hiding it (2026-07-11).
+	BlockReason        string    `json:"block_reason,omitempty"`
 	IsPinned           bool      `json:"is_pinned"`
 	QueueIndex         int       `json:"queue_index"`          // 1-based for ACTIVE/QUEUED/IDLE; 0 otherwise
 	EtaMinutes         int       `json:"eta_minutes"`          // RequiredMinutesWatched - CurrentMinutesWatched of next-to-claim drop
+}
+
+// recomputeDerived recalculates Percent and EtaMinutes from Progress and
+// Required. Both are pure functions of those two fields, so storing them
+// independently invites divergence: a progress event that advances
+// Progress without recomputing Percent/EtaMinutes (e.g. when Required was
+// momentarily 0) leaves the row showing a stale "248/300min (88%)" where
+// the percentage no longer matches the minutes. Every writer of Progress
+// or Required MUST call this before the row is published so the three
+// fields can never disagree on screen.
+func (d *ActiveDrop) recomputeDerived() {
+	if d.Required <= 0 {
+		d.Percent = 0
+		d.EtaMinutes = 0
+		return
+	}
+	pct := (d.Progress * 100) / d.Required
+	if pct > 100 {
+		pct = 100
+	}
+	d.Percent = pct
+	eta := d.Required - d.Progress
+	if eta < 0 {
+		eta = 0
+	}
+	d.EtaMinutes = eta
 }
 
 // RowsConfig is the slice of config behavior BuildRows depends on.
@@ -107,16 +137,15 @@ func BuildRows(
 		}
 
 		// Same eligibility as Selector.filterEligibleCampaigns: account-link
-		// OR badge/emote benefit. Skipping this parity caused 80%+ of
-		// campaigns to vanish from the UI even though the selector was
-		// happily picking them in the background.
-		if !c.IsAccountConnected && !hasBadgeOrEmoteBenefit(c) {
-			continue
-		}
-
-		// Skip campaigns with no watchable drops (sub-only, or all drops claimed).
-		// These can't be farmed, so showing them in the queue is just noise.
-		// EXCEPTION: keep them if disabled or completed so the user can see why.
+		// OR badge/emote benefit; plus the no-watchable-drops check.
+		//
+		// Transparency (2026-07-11): wanted-game campaigns failing one of
+		// these gates used to vanish from the UI entirely — the user
+		// couldn't tell why a visibly-running campaign wasn't farmed
+		// (live case: Anno 117, Ubisoft account not linked). They now
+		// surface as BLOCKED rows with a human-readable reason. Campaigns
+		// of non-wanted games keep vanishing (noise), disabled/completed
+		// ones keep their regular status rows.
 		hasWatchable := false
 		for _, d := range c.Drops {
 			if d.RequiredMinutesWatched > 0 && !d.IsClaimed {
@@ -124,7 +153,32 @@ func BuildRows(
 				break
 			}
 		}
-		if !hasWatchable && !cfg.IsCampaignDisabled(c.ID) && !cfg.IsCampaignCompleted(c.ID) {
+		// Zwei Klassen unterscheiden (2026-07-17):
+		//   BLOCKED = echter Handlungsbedarf des Users (Konto nicht verknüpft —
+		//     der Path-of-Exile/Anno-Fall: farmbar erst nach dem Verknüpfen).
+		//     Bleibt in der UI auffällig (gelb).
+		//   IDLE    = harmlos nicht-farmbar (alle Drops erhalten / gerade kein
+		//     Drop im Fenster). KEIN Handlungsbedarf — v.a. die täglichen
+		//     Marble-Kampagnen nach dem Claim. Unauffällig, kein Alarm.
+		blockStatus, blockReason := "", ""
+		if !c.IsAccountConnected && !hasBadgeOrEmoteBenefit(c) {
+			blockStatus, blockReason = "BLOCKED", "Konto nicht verknüpft"
+		} else if !hasWatchable {
+			blockStatus, blockReason = "IDLE", "nichts offen"
+		}
+		if blockStatus != "" && !cfg.IsCampaignDisabled(c.ID) && !cfg.IsCampaignCompleted(c.ID) {
+			if !useAutoMarker {
+				// No wanted list configured — keep the old hide-it behavior.
+				continue
+			}
+			if seenWatchableNames[c.Name] {
+				continue
+			}
+			seenWatchableNames[c.Name] = true
+			row := campaignToRow(c, pinnedID)
+			row.Status = blockStatus
+			row.BlockReason = blockReason
+			idle = append(idle, row)
 			continue
 		}
 
@@ -204,30 +258,4 @@ func campaignToRow(c twitch.DropCampaign, pinnedID string) ActiveDrop {
 	}
 	row.recomputeDerived()
 	return row
-}
-
-// recomputeDerived recalculates Percent and EtaMinutes from Progress and
-// Required. Both are pure functions of those two fields, so storing them
-// independently invites divergence: a progress event that advances
-// Progress without recomputing Percent/EtaMinutes (e.g. when Required was
-// momentarily 0) leaves the row showing a stale "248/300min (88%)" where
-// the percentage no longer matches the minutes. Every writer of Progress
-// or Required MUST call this before the row is published so the three
-// fields can never disagree on screen.
-func (d *ActiveDrop) recomputeDerived() {
-	if d.Required <= 0 {
-		d.Percent = 0
-		d.EtaMinutes = 0
-		return
-	}
-	pct := (d.Progress * 100) / d.Required
-	if pct > 100 {
-		pct = 100
-	}
-	d.Percent = pct
-	eta := d.Required - d.Progress
-	if eta < 0 {
-		eta = 0
-	}
-	d.EtaMinutes = eta
 }

--- a/internal/drops/rows.go
+++ b/internal/drops/rows.go
@@ -32,39 +32,12 @@ type ActiveDrop struct {
 	// auto-discovered and the marker would be noise).
 	IsAutoDiscovered bool `json:"is_auto_discovered"`
 	Status             string    `json:"status"`               // ACTIVE / QUEUED / IDLE / DISABLED / COMPLETED / BLOCKED
-	// BlockReason explains a BLOCKED status in one short phrase
-	// ("account not linked", …) so the UI can show WHY a wanted-game
-	// campaign isn't being farmed instead of hiding it (2026-07-11).
+	// BlockReason explains a BLOCKED (or IDLE) status in one short phrase
+	// so the UI can show WHY a wanted-game campaign isn't being farmed.
 	BlockReason        string    `json:"block_reason,omitempty"`
 	IsPinned           bool      `json:"is_pinned"`
 	QueueIndex         int       `json:"queue_index"`          // 1-based for ACTIVE/QUEUED/IDLE; 0 otherwise
 	EtaMinutes         int       `json:"eta_minutes"`          // RequiredMinutesWatched - CurrentMinutesWatched of next-to-claim drop
-}
-
-// recomputeDerived recalculates Percent and EtaMinutes from Progress and
-// Required. Both are pure functions of those two fields, so storing them
-// independently invites divergence: a progress event that advances
-// Progress without recomputing Percent/EtaMinutes (e.g. when Required was
-// momentarily 0) leaves the row showing a stale "248/300min (88%)" where
-// the percentage no longer matches the minutes. Every writer of Progress
-// or Required MUST call this before the row is published so the three
-// fields can never disagree on screen.
-func (d *ActiveDrop) recomputeDerived() {
-	if d.Required <= 0 {
-		d.Percent = 0
-		d.EtaMinutes = 0
-		return
-	}
-	pct := (d.Progress * 100) / d.Required
-	if pct > 100 {
-		pct = 100
-	}
-	d.Percent = pct
-	eta := d.Required - d.Progress
-	if eta < 0 {
-		eta = 0
-	}
-	d.EtaMinutes = eta
 }
 
 // RowsConfig is the slice of config behavior BuildRows depends on.
@@ -136,16 +109,8 @@ func BuildRows(
 			continue
 		}
 
-		// Same eligibility as Selector.filterEligibleCampaigns: account-link
-		// OR badge/emote benefit; plus the no-watchable-drops check.
-		//
-		// Transparency (2026-07-11): wanted-game campaigns failing one of
-		// these gates used to vanish from the UI entirely — the user
-		// couldn't tell why a visibly-running campaign wasn't farmed
-		// (live case: Anno 117, Ubisoft account not linked). They now
-		// surface as BLOCKED rows with a human-readable reason. Campaigns
-		// of non-wanted games keep vanishing (noise), disabled/completed
-		// ones keep their regular status rows.
+		// Campaigns with no watchable drops (sub-only, or all drops claimed)
+		// can't be farmed. Needed by the block classification below.
 		hasWatchable := false
 		for _, d := range c.Drops {
 			if d.RequiredMinutesWatched > 0 && !d.IsClaimed {
@@ -153,22 +118,30 @@ func BuildRows(
 				break
 			}
 		}
-		// Zwei Klassen unterscheiden (2026-07-17):
-		//   BLOCKED = echter Handlungsbedarf des Users (Konto nicht verknüpft —
-		//     der Path-of-Exile/Anno-Fall: farmbar erst nach dem Verknüpfen).
-		//     Bleibt in der UI auffällig (gelb).
-		//   IDLE    = harmlos nicht-farmbar (alle Drops erhalten / gerade kein
-		//     Drop im Fenster). KEIN Handlungsbedarf — v.a. die täglichen
-		//     Marble-Kampagnen nach dem Claim. Unauffällig, kein Alarm.
+
+		// A wanted-game campaign that cannot be farmed is now surfaced
+		// instead of silently dropped, so the user can see WHY. Both gates
+		// (eligibility — same parity as Selector.filterEligibleCampaigns —
+		// and "nothing watchable") feed one classification:
+		//
+		//   BLOCKED = the user has to act (game account not linked). Shown
+		//             prominently, because this silently costs drops.
+		//   IDLE    = harmless: every drop already claimed, or nothing in
+		//             its time window right now. No action needed.
+		//
+		// Campaigns of games that are NOT in the wanted list keep being
+		// hidden — surfacing those would just be noise. Disabled and
+		// completed campaigns keep their own status.
 		blockStatus, blockReason := "", ""
 		if !c.IsAccountConnected && !hasBadgeOrEmoteBenefit(c) {
-			blockStatus, blockReason = "BLOCKED", "Konto nicht verknüpft"
+			blockStatus, blockReason = "BLOCKED", "account not linked"
 		} else if !hasWatchable {
-			blockStatus, blockReason = "IDLE", "nichts offen"
+			blockStatus, blockReason = "IDLE", "nothing open"
 		}
 		if blockStatus != "" && !cfg.IsCampaignDisabled(c.ID) && !cfg.IsCampaignCompleted(c.ID) {
 			if !useAutoMarker {
-				// No wanted list configured — keep the old hide-it behavior.
+				// No wanted list configured — keep the previous behaviour
+				// of hiding non-farmable campaigns entirely.
 				continue
 			}
 			if seenWatchableNames[c.Name] {
@@ -258,4 +231,30 @@ func campaignToRow(c twitch.DropCampaign, pinnedID string) ActiveDrop {
 	}
 	row.recomputeDerived()
 	return row
+}
+
+// recomputeDerived recalculates Percent and EtaMinutes from Progress and
+// Required. Both are pure functions of those two fields, so storing them
+// independently invites divergence: a progress event that advances
+// Progress without recomputing Percent/EtaMinutes (e.g. when Required was
+// momentarily 0) leaves the row showing a stale "248/300min (88%)" where
+// the percentage no longer matches the minutes. Every writer of Progress
+// or Required MUST call this before the row is published so the three
+// fields can never disagree on screen.
+func (d *ActiveDrop) recomputeDerived() {
+	if d.Required <= 0 {
+		d.Percent = 0
+		d.EtaMinutes = 0
+		return
+	}
+	pct := (d.Progress * 100) / d.Required
+	if pct > 100 {
+		pct = 100
+	}
+	d.Percent = pct
+	eta := d.Required - d.Progress
+	if eta < 0 {
+		eta = 0
+	}
+	d.EtaMinutes = eta
 }

--- a/internal/drops/selector.go
+++ b/internal/drops/selector.go
@@ -195,6 +195,18 @@ func (s *Selector) filterEligibleCampaigns(campaigns []twitch.DropCampaign) []tw
 		}
 		if !hasWatchable {
 			logWantedReject(c, "no_earnable")
+			// Per-drop diagnostics for wanted-game campaigns (added
+			// 2026-07-11 while chasing the Marble Day "no_earnable"
+			// mystery): shows exactly which IsEarnable clause rejects
+			// each drop — required-minutes missing, claim flags, time
+			// window or precondition IDs.
+			if s.diagFn != nil && hasWantedFilter && wantedSet[strings.ToLower(strings.TrimSpace(c.GameName))] {
+				for _, d := range c.Drops {
+					s.diagFn("[Drops/Diag]   drop id=%.8s req=%d claimed=%t cur=%d window=%s..%s preconds=%v",
+						d.ID, d.RequiredMinutesWatched, d.IsClaimed, d.CurrentMinutesWatched,
+						d.StartAt.Format("01-02T15:04"), d.EndAt.Format("01-02T15:04"), shortIDs(d.PreconditionDrops))
+				}
+			}
 			stats.NoEarnableDrops++
 			continue
 		}
@@ -444,3 +456,12 @@ func hasBadgeOrEmoteBenefit(c twitch.DropCampaign) bool {
 // from the most recent Select. 0 with Eligible>0 means the filter passed
 // campaigns but no live drops-enabled streamer was found for any of them.
 func (s *Selector) LastPoolSize() int { return s.lastPoolSize }
+
+// shortIDs maps a list of drop IDs to their 8-char prefixes for log lines.
+func shortIDs(ids []string) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = shortID(id)
+	}
+	return out
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -431,6 +431,7 @@
         .status-pill.idle       { color: var(--text-muted); border: 1px solid var(--rule-soft); }
         .status-pill.disabled   { color: var(--text-dim); border: 1px solid var(--rule-soft); }
         .status-pill.completed  { color: var(--text-dim); border: 1px solid transparent; opacity: 0.5; }
+        .status-pill.blocked    { color: #d0a030; border: 1px solid #d0a030; }
 
         .toggle {
             position: relative;
@@ -1204,6 +1205,7 @@
                 const campaignTd = el('td');
                 campaignTd.appendChild(document.createTextNode(d.campaign_name));
                 if (d.is_auto_discovered) campaignTd.appendChild(el('span', { class: 'auto-tag', text: 'Auto' }));
+                if (d.block_reason) campaignTd.appendChild(el('span', { class: 'auto-tag', text: d.block_reason }));
 
                 const progress = d.required > 0
                     ? d.progress + '/' + d.required + ' · ' + d.percent + '%'
@@ -1227,7 +1229,9 @@
             }
             const activeCount = state.drops.filter(d => d.status === 'ACTIVE').length;
             const queuedCount = state.drops.filter(d => d.status === 'QUEUED').length;
-            $('#drops-meta').textContent = activeCount + ' active · ' + queuedCount + ' queued · ' + state.drops.length + ' total';
+            const blockedCount = state.drops.filter(d => d.status === 'BLOCKED').length;
+            $('#drops-meta').textContent = activeCount + ' active · ' + queuedCount + ' queued ·'
+                + (blockedCount ? ' ' + blockedCount + ' blocked ·' : '') + ' ' + state.drops.length + ' total';
         }
 
         $('#drops-body').addEventListener('click', async (e) => {


### PR DESCRIPTION
Two visibility improvements from running this long-term. Both are about the
same class of problem: when the bot *isn't* farming something, it's currently
hard to find out why.

> Note: `go test ./...` shows four failing selector tests on this branch. They
> are pre-existing on `main` (fixture keys vs. game slugs, unrelated to this
> change) and are fixed by the companion PR. This branch doesn't touch them.

### 1. `feat(web)`: BLOCKED status with a reason

A campaign in `wanted_games` that the bot cannot farm was indistinguishable
from one that's simply idle — both showed up as `IDLE`. So a real
misconfiguration (game account not linked to Twitch) looked exactly like
"nothing to do right now". In my case an Anno 117 campaign sat there for days
before I noticed the account link was missing; drops were silently lost the
whole time.

Both non-farmable gates now feed one classification:

- **BLOCKED** — the user has to act. Currently raised when the account link is
  missing. Reason: `account not linked`.
- **IDLE** — harmless: every drop already claimed, or nothing in its time
  window right now. No action needed.

The web UI shows BLOCKED in amber with the reason next to the campaign name
and counts blocked campaigns in the drops-tab header, so the tab tells you at
a glance whether something needs attention.

Deliberately narrow:

- Campaigns of games **not** in `wanted_games` keep being hidden — surfacing
  those would just be noise.
- With no `wanted_games` configured at all, the previous hide-it behaviour is
  kept unchanged.
- `BlockReason` is `omitempty`, so the `/api/drops` payload is byte-identical
  for every campaign that isn't blocked.

### 2. `feat(drops)`: per-drop reasons behind a `no_earnable` rejection

`no_earnable` is the hardest rejection to diagnose: the campaign is ACTIVE,
the account is linked, drops are present — yet no drop passes `IsEarnable`,
and the log doesn't say which of the four conditions is responsible (missing
`requiredMinutesWatched`, already claimed, outside the drop's own time window,
unclaimed precondition).

When a wanted-game campaign is rejected for that reason, each drop is now
logged with exactly the fields `IsEarnable` looks at:

```
[Drops/Diag]   drop id=dfcf3f74 req=30 claimed=true cur=240 \
               window=07-21T16:00..07-28T22:58 preconds=[]
```

This is what let me identify the zeroed-counter behaviour that you fixed in
v2.1.7 — the line showed `claimed=true cur=240` for every drop while the
campaign kept being re-picked.

Scoped so it stays quiet in normal operation: only when the diagnostic sink is
set (`s.diagFn != nil`), only for campaigns whose game is in `wanted_games`,
and only on the `no_earnable` path. Users without a wanted-games filter see no
additional output at all.

### Testing

- `go build ./...` — clean
- Both changes running on a Pi 4 against a live account; BLOCKED correctly
  raised for an unlinked game account and cleared after linking it